### PR TITLE
Fix Stable Marriage Tray Issues

### DIFF
--- a/Mgr.cpp
+++ b/Mgr.cpp
@@ -169,7 +169,7 @@ void Mgr::printClusterStats()
     cout << "MAX cluster size: " <<max_cluster_size <<endl;
     cout << "MIN cluster size: " <<min_cluster_size << endl;
     cout << "clusters size is 1: " << counting << endl;
-    cout << "clusters size is 80: " << count80 << endl;
+    cout << "clusters size is " << getParamMgr().MaxClusterSize << ": " << count80 << endl;
     cout << "total displacement: " << totDisp << endl;
     cout << "max displacement: " << maxDisp << endl;
     cout << "avg displacement: " << avgDisp << endl;

--- a/StableMatching.cpp
+++ b/StableMatching.cpp
@@ -19,7 +19,7 @@ StableMatching::StableMatching()
     _clusters.resize (m.getFFSize());
     _FFs.resize(m.getClusterSize());
     for (int i = 0; i < m.getFFSize(); i++)
-        _clusters[i].reserve(capacity);
+        _clusters[i].reserve(m.getClusterSize());
 }
 bool StableMatching::run()
 {
@@ -62,8 +62,8 @@ void StableMatching::calcClusters(std::vector<FF_id>& order)
     {
         FF& nowFF = m.getFF (id);
         std::vector<PointWithID> resultClusters;
-        resultClusters.reserve (capacity);
-        _rtree.query (bgi::nearest (Point (nowFF.getOrigX(), nowFF.getOrigY()), capacity),
+        resultClusters.reserve (m.getClusterSize());
+        _rtree.query (bgi::nearest (Point (nowFF.getOrigX(), nowFF.getOrigY()), m.getClusterSize()),
         std::back_inserter (resultClusters));
 
         BOOST_FOREACH (PointWithID const & c, resultClusters)
@@ -126,7 +126,7 @@ bool StableMatching::prefersThisFF(Cluster_id cid, mDist dis)
 }
 void StableMatching::match(std::vector<FF_id>& order)
 {
-    auto& m = getMgr();
+    //auto& m = getMgr();
     for (int i = 0; i < (int)order.size(); i++)
     {
         FF_id fid = order[i];
@@ -135,8 +135,8 @@ void StableMatching::match(std::vector<FF_id>& order)
         {
             mDist      dis = _clusters[fid][j].first;
             Cluster_id cid = _clusters[fid][j].second;
-            Cluster& c = m.getCluster(cid);
-            if (c.isFull())
+            //Cluster& c = m.getCluster(cid);
+            if ((int)_FFs[cid].size() >= getParamMgr().MaxClusterSize)
             {
                 if (prefersThisFF(cid, dis))
                 {


### PR DESCRIPTION
"c.isFull()" always returns false since the cluster size is never updated during match() (in StableMatching.cpp). Thus, you can create trays that have #slots >= MaxClusterSize. 
_FFs gets updated, so I changed the if statement. MaxClusterSize goes unviolated now. 

"capacity" = 100 does not seem to work well when MaxClusterSize is small (in my experiments, 4). If you only look at "capacity" = 100 number of potential clusters, this means that, in the worst case, you can end up having FFs that don't get clustered (if all FFs have the same potential MBFF candidates, then only 400 FFs would be matched here). This is an extreme example, but the reasoning applies for smaller cases where "capacity" hinders clusterings.

I hope this makes sense!